### PR TITLE
Rework ENV vars

### DIFF
--- a/deploy-commands.ts
+++ b/deploy-commands.ts
@@ -121,7 +121,7 @@ const commands = [
 ]
     .map(command => command.toJSON());
 
-const rest = new REST({ version: '9' }).setToken(<string>process.env.token);
+const rest = new REST({ version: '9' }).setToken(<string>process.env.STOCKPILER_TOKEN);
 
 
 const insertCommands = async () => {
@@ -129,14 +129,14 @@ const insertCommands = async () => {
     // ClientId is the bot "Copy ID"
     // GuildId is the server "Copy ID"
     if (process.env.NODE_ENV === "development") {
-        await rest.put(Routes.applicationGuildCommands(<string>process.env.clientId, <string>process.env.guildId), { body: commands })
+        await rest.put(Routes.applicationGuildCommands(<string>process.env.STOCKPILER_CLIENT_ID, <string>process.env.STOCKPILER_GUILD_ID), { body: commands })
             .then(() => console.log('Successfully registered application commands to guild.'))
             .catch(console.error);
     }
     // Global commands for deployment (Global commands take at least 1 hour to update after each change)
     else {
         await rest.put(
-            Routes.applicationCommands(<string>process.env.clientId),
+            Routes.applicationCommands(<string>process.env.STOCKPILER_CLIENT_ID),
             { body: commands },
         ).then(() => console.log('Successfully registered application commands globally.'))
             .catch(console.error);

--- a/index.ts
+++ b/index.ts
@@ -176,7 +176,7 @@ const main = async (): Promise<void> => {
         });
 
         // Connect by logging into Discord
-        client.login(process.env.token)
+        client.login(process.env.STOCKPILER_TOKEN)
     }
     else {
         console.error("Failed to connect to MongoDB. Exiting now")

--- a/mongoDB.ts
+++ b/mongoDB.ts
@@ -9,7 +9,14 @@ let collections: collectionList;
 
 
 const open = async (): Promise<boolean> => {
-    const status = await MongoClient.connect("mongodb://localhost:27017", {
+    let uri = "mongodb://localhost:27017"
+    if (process.env.MONGODB_URI) {
+        uri = process.env.MONGODB_URI
+    }
+
+    console.info("Connecting to MongoDB at " + uri)
+
+    const status = await MongoClient.connect(uri, {
     }).then(async (client) => {
         const db = client.db('stockpiler')
         collections = {


### PR DESCRIPTION
This PR switches the bot to use `ALL_CAPS`-style env vars, as is \*nix convention.

It also adds `MONGODB_URI` to allow customizing the location of the Mongo server.