### PR TITLE
fix(docker): node environment not set causing mismatch port in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,7 @@ COPY --from=npm /app/node_modules ./node_modules
 COPY . .
 RUN npx tsc
 
+ENV NODE_ENV=development
+
 EXPOSE 8090
 CMD ["node", "index.js"]


### PR DESCRIPTION
`NODE_ENV` is not set causing the bot to default to port `80`, while port `8090` is exposed. This caused a very unpleasant outage due to Traefik trying to route the `8090` port after an update on my deployment.

Also on an unrelated note, you have `typescript` as a normal dependency, that should probably be a dev dependency. Also you have the dev dependencies installed in the final image which also include the ts files, bloating the image somewhat. Use a stage to compile the typescript, and then copy all the compiled files to the final stage. For the final image also don't copy the `node_modules` folder but run `npm ci --production` instead.